### PR TITLE
Appdata related patches

### DIFF
--- a/data/io.github.seadve.Delineate.metainfo.xml.in.in
+++ b/data/io.github.seadve.Delineate.metainfo.xml.in.in
@@ -28,6 +28,10 @@
       <image>https://raw.githubusercontent.com/SeaDve/Delineate/main/data/resources/screenshots/screenshot3.png</image>
     </screenshot>
   </screenshots>
+  <branding>
+    <color type="primary" scheme_preference="light">#ff00ff</color>
+    <color type="primary" scheme_preference="dark">#993d3d</color>
+  </branding>
   <url type="bugtracker">https://github.com/SeaDve/Delineate/issues</url>
   <url type="homepage">https://github.com/SeaDve/Delineate</url>
   <url type="donation">https://seadve.github.io/donate/</url>

--- a/data/io.github.seadve.Delineate.metainfo.xml.in.in
+++ b/data/io.github.seadve.Delineate.metainfo.xml.in.in
@@ -19,6 +19,7 @@
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/SeaDve/Delineate/main/data/resources/screenshots/screenshot1.png</image>
+      <caption>Main window in light mode</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/SeaDve/Delineate/main/data/resources/screenshots/screenshot2.png</image>


### PR DESCRIPTION
### appdata: Add branding colors

### appdata: Update screenshot

- Fix screenshot URL
- Add a caption

### appdata: `translate=no` properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract the
`translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html
